### PR TITLE
test: use 'edge' (unreleased) elastic-otel-python Docker image for Python auto-instrumentation

### DIFF
--- a/test/operator/elastic-instrumentation.yml
+++ b/test/operator/elastic-instrumentation.yml
@@ -20,6 +20,6 @@ spec:
   dotnet:
     image: docker.elastic.co/observability/elastic-otel-dotnet:edge
   python:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:0.48b0
+    image: docker.elastic.co/observability/elastic-otel-python:edge
   go:
     image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.14.0-alpha


### PR DESCRIPTION
/cc @xrmx
This mimics https://github.com/jackshirazi/opentelemetry/pull/1
Jack has a fork of elastic/opentelemetry that adds a very basic test of auto-instrumentation with the OTel Operator.
This is a PR to switch to using your new elastic-otel-python image for that instrumentation.
