### PR TITLE
test: use release versions of the elastic-otel-node and elastic-otel-python Docker images, now that we have them

### DIFF
--- a/test/operator/elastic-instrumentation.yml
+++ b/test/operator/elastic-instrumentation.yml
@@ -16,10 +16,10 @@ spec:
   java:
     image: docker.elastic.co/observability/elastic-otel-javaagent:1.0.0
   nodejs:
-    image: docker.elastic.co/observability/elastic-otel-node:edge
+    image: docker.elastic.co/observability/elastic-otel-node:0.4.1
   dotnet:
     image: docker.elastic.co/observability/elastic-otel-dotnet:edge
   python:
-    image: docker.elastic.co/observability/elastic-otel-python:edge
+    image: docker.elastic.co/observability/elastic-otel-python:0.3.0
   go:
     image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.14.0-alpha


### PR DESCRIPTION
/cc @xrmx

@jackshirazi Did you have thoughts/plans on keeping these docker image version tags up to date? Or had you considering using the `latest` tag?
